### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+## [v0.5.0] - 2026-05-30
+
+### Bug Fixes
+
+- `Score.stop()` 後に `Score.play()` を呼ぶと音が鳴らない問題を修正
+
+### Breaking Changes
+
+- `Tone.stop()` の挙動変更: OscillatorNode の破棄を行わなくなった（ゲインを 0 にして再生停止するのみ）。リソースの完全解放は `destroy()` を使うこと
+
+### Features
+
+- `Score.destroy()` を新設: AudioContext・OscillatorNode 等のリソースを完全解放（使い捨て）
+- `Tone.destroy()` を新設: OscillatorNode・GainNode を `stop()` / `disconnect()` して解放
+
+### Chores
+
+- pnpm 11 の `allowBuilds` 設定に移行
+- `lint` / `lint:fix` スクリプトを追加
+- GitHub Pages デプロイ追加（`production` タグトリガー）
+
+---
+
+## [v0.4.0] - 2026-05-07
+
+### Breaking Changes
+
+- `Score` クラスのイベント機構を Node の `EventEmitter` から Web 標準 `EventTarget` に移行
+  - リスナー登録: `score.addListener("change", h)` → `score.on("change", h)`（標準の `addEventListener` も使用可）
+  - リスナー受け取り: payload オブジェクトを廃止し、`event.target` から Score インスタンスを参照
+  - `EventEmitter` 由来のメソッド（`once`, `off`, `removeAllListeners` 等）は廃止。代替は `addEventListener(type, listener, { once: true })` / `AbortSignal` 経由の cleanup
+
+### Features
+
+- `node:events` / `events` polyfill への依存を撤去。bundler 設定なしで browser/Node 両環境で動作
+- 型強化された `on(type, listener, options?)` ヘルパーを追加
+
+---
+
+## [v0.3.0] - 2026-05-07
+
+### Features
+
+- `Score.seek(frame)` メソッドを追加（再生位置の制御）
+  - 整数チェック・範囲チェック失敗時は `Error` を返却
+  - 再生中の seek もタイマー継続、次の process tick でコードが自動追従
+
+### Chores
+
+- TypeScript を 6.0.3 へ移行（5.6 → 6.0）
+- pnpm v10 builds 承認設定
+- CI Node matrix を `[22, 24]` に更新
+- `jest` 30.3.0、`styled-components` 6.4.1 へ bump
+
+---
+
+## [v0.2.0] - 2026-03-20
+
+### Features
+
+- コード（和音）機能を追加: メジャー/マイナー/7th/マイナー7th × 12キー = 48種類 + 伝統音階6種類（都節・律・民謡・琉球・中国・ブルース）
+- プリセット機能を追加: ADSR エンベロープ・波形切替・マスターゲインに対応した10種類の音色プリセット
+
+### Refactoring
+
+- `IScoreData` の構造を `measures` に統合し、小節単位でコード情報を管理するように変更
+
+### Chores
+
+- パッケージマネージャーを npm から pnpm に移行
+- CI ワークフローの追加
+- Biome 設定の更新
+
+---
+
+## [v0.1.1] - 2024-11-02
+
+バグ修正リリース。
+
+---
+
+## [v0.1.0] - 2024-10-26
+
+Initial release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,15 @@ npx jest __tests__/index.spec.ts
 # Run tests matching a pattern
 npx jest -t "initialize"
 
-# Lint and format (Biome)
-npx biome check .
-npx biome check --write .
+# Lint (Biome)
+pnpm run lint
+pnpm run lint:fix
 
 # Run example app (Parcel dev server)
 pnpm run example
+
+# Build example app for GitHub Pages
+pnpm run build:example
 ```
 
 ## Architecture
@@ -50,11 +53,13 @@ pnpm run example
   - 再生ループは `setTimeout` ベース。`process()` が再帰的にフレームを進行
   - マスターゲインノード（`1/16`）で16音の同時発音時のクリッピングを防止
   - 操作メソッド（`toggleNote`, `addMeasure`, `setChord`, `setPreset`, `seek` 等）は失敗時に `Error` を返し、成功時は `undefined` を返すパターン（throw しない）
+  - `destroy()` で AudioContext（自前生成時のみ）・masterGain・Tone 全インスタンスを完全解放（使い捨て。以降の再利用不可）
 
 - **Tone** (`src/lib/Tone.ts`): Web Audio の OscillatorNode + GainNode のラッパー
   - プリセットに応じた波形タイプ（sine, square, sawtooth, triangle, custom PeriodicWave）を設定
   - ADSRエンベロープによるゲイン制御。`ping()` で Web Audio のスケジューリング API を使用
-  - `stop()` でオシレーター・ゲインノードを適切に `stop()` / `disconnect()` してリソース解放
+  - `stop()` はゲインを 0 にして再生停止するのみ（OscillatorNode は維持するため `play()` で再開可能）
+  - `destroy()` でオシレーター・ゲインノードを `stop()` / `disconnect()` してリソース完全解放（使い捨て）
 
 ### Data Structure
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ score.stop();
 | `setPreset(preset: PresetName)` | 音色プリセットを変更 |
 | `setSpeed(speed: number)` | 再生速度を設定（フレーム/秒） |
 | `randomize(measureIndex, callback?)` | 指定小節をランダム化 |
-| `play()` | 再生開始 |
-| `stop()` | 再生停止 |
+| `play()` | 再生開始（stop() 後の再開も可） |
+| `stop()` | 再生停止（OscillatorNode は維持されるため、play() で再開できる） |
 | `seek(frame: number)` | 再生位置を任意のフレームに移動（0〜小節数×16-1） |
+| `destroy()` | AudioContext・OscillatorNode 等のリソースを完全解放（使い捨て。以降の再利用不可） |
 | `on(type, listener, options?)` | 型強化されたイベント登録ヘルパー（`change` / `process`） |
 
 #### イベント
@@ -158,6 +159,10 @@ pnpm run typecheck
 
 # テスト
 pnpm test
+
+# Lint
+pnpm run lint
+pnpm run lint:fix
 
 # サンプルアプリの起動
 pnpm run example

--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
       "**",
       "!**/dist",
       "!**/.parcel-dist",
+      "!**/.pages-dist",
       "!**/coverage",
       "!**/.claude",
       "!**/.vscode"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "score.ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A 16-step sequencer library built with Web Audio API and TypeScript, featuring chord-based tone generation with 48 chords, 6 traditional scales, and 10 sound presets",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

- `Score.stop()` 後に `Score.play()` を呼ぶと音が鳴らないバグを修正
- リソース完全解放用の `destroy()` メソッドを新設
- GitHub Pages デプロイ設定を追加
- ドキュメント整備（CHANGELOG 新設・README / CLAUDE.md 更新）

## Changes

### Bug Fixes
- `Tone.stop()` を「再生停止のみ」に変更（OscillatorNode を維持するため `play()` で再開可能）

### Breaking Changes
- `Tone.stop()` がリソースを破棄しなくなった。完全解放は `Score.destroy()` / `Tone.destroy()` を使うこと

### Features
- `Score.destroy()` / `Tone.destroy()` 新設: AudioContext・OscillatorNode 等を完全解放（使い捨て）
- `lint` / `lint:fix` スクリプト追加（Biome）
- GitHub Pages デプロイワークフロー追加（`production` タグ push でトリガー）

### Chores
- pnpm 11 の `allowBuilds` 設定に移行
- `parcel` を devDependencies に追加

### Docs
- `CHANGELOG.md` 新設（v0.1.0 〜 v0.5.0）
- `README.md`: `destroy()` 追加、`stop()` 説明修正、lint コマンド追加
- `CLAUDE.md`: `Tone.stop()` / `destroy()` 説明更新、コマンド更新

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm test`（30件）
- [x] `pnpm run lint`
- [x] `pnpm run build:example`