### PR TITLE
feat: playingchange イベントを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ pnpm run build:example
 ### Core Classes
 
 - **Score** (`src/lib/Score.ts`): スコアデータの管理と再生を担うメインクラス
-  - `EventTarget` を継承。`change`（データ変更時）と `process`（フレーム進行時）イベントを発火。リスナーは `e.target` から Score インスタンスを参照可能
+  - `EventTarget` を継承。`change`（データ変更時）・`process`（フレーム進行時）・`playingchange`（`play()` / `stop()` による再生状態変化時）イベントを発火。リスナーは `e.target` から Score インスタンスを参照可能
   - 型強化された `on(type, listener, options?)` ヘルパーを提供（標準の `addEventListener` も利用可能）
   - 最大16小節、各小節は16フレーム × 16ノートのグリッド構造
   - 再生ループは `setTimeout` ベース。`process()` が再帰的にフレームを進行

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ score.on("process", (e) => {
   console.log("現在のフレーム:", e.target.currentFrame);
 });
 
+// 再生状態が変わったときのイベントリスナー
+score.on("playingchange", (e) => {
+  console.log("再生状態:", e.target.playing); // true or false
+});
+
 // ノートをトグル（小節インデックス, フレームインデックス, ノートインデックス）
 score.toggleNote(0, 0, 0);
 
@@ -79,7 +84,7 @@ score.stop();
 | `stop()` | 再生停止（OscillatorNode は維持されるため、play() で再開できる） |
 | `seek(frame: number)` | 再生位置を任意のフレームに移動（0〜小節数×16-1） |
 | `destroy()` | AudioContext・OscillatorNode 等のリソースを完全解放（使い捨て。以降の再利用不可） |
-| `on(type, listener, options?)` | 型強化されたイベント登録ヘルパー（`change` / `process`） |
+| `on(type, listener, options?)` | 型強化されたイベント登録ヘルパー（`change` / `process` / `playingchange`） |
 
 #### イベント
 
@@ -89,6 +94,7 @@ score.stop();
 |---------|------|
 | `change` | データが変更されたとき |
 | `process` | フレームが進んだとき |
+| `playingchange` | `play()` / `stop()` で再生状態が変わったとき（`e.target.playing` で現在値を参照） |
 
 ### IScoreData インターフェース
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -301,6 +301,45 @@ describe("Score Class", () => {
     expect(score.tones?.every((tone) => !tone.playing)).toBe(true);
   });
 
+  test("play emits playingchange with playing = true", () => {
+    jest.useFakeTimers();
+    const score = new Score();
+    score.connect(mockAudioContext as unknown as AudioContext);
+    const handler = jest.fn();
+    score.on("playingchange", handler);
+
+    score.play();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0][0] as Event).target).toBe(score);
+    expect(score.playing).toBe(true);
+    score.stop();
+  });
+
+  test("stop emits playingchange with playing = false", () => {
+    jest.useFakeTimers();
+    const score = new Score();
+    score.connect(mockAudioContext as unknown as AudioContext);
+    score.play();
+    const handler = jest.fn();
+    score.on("playingchange", handler);
+
+    score.stop();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(score.playing).toBe(false);
+  });
+
+  test("destroy does not emit playingchange", () => {
+    jest.useFakeTimers();
+    const score = new Score();
+    score.connect(mockAudioContext as unknown as AudioContext);
+    score.play();
+    const handler = jest.fn();
+    score.on("playingchange", handler);
+
+    score.destroy();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   test("replay after stop reuses tones without recreating oscillators", () => {
     jest.useFakeTimers();
     const score = new Score();

--- a/dist/cjs/lib/Score.d.ts
+++ b/dist/cjs/lib/Score.d.ts
@@ -1,7 +1,7 @@
 import { type ChordName } from "../const/chords_notes";
 import { type PresetName } from "../const/presets";
 import { Tone } from "./Tone";
-type ScoreEventName = "change" | "process";
+type ScoreEventName = "change" | "process" | "playingchange";
 type ScoreEvent<K extends ScoreEventName> = Event & {
     type: K;
     target: Score;

--- a/dist/cjs/lib/Score.js
+++ b/dist/cjs/lib/Score.js
@@ -206,6 +206,7 @@ class Score extends EventTarget {
             }
         }
         this.process();
+        this.emit("playingchange");
     }
     stop() {
         clearTimeout(this.timer);
@@ -216,6 +217,7 @@ class Score extends EventTarget {
                 tone.stop();
             }
         }
+        this.emit("playingchange");
     }
     seek(frame) {
         if (!Number.isInteger(frame)) {

--- a/dist/esm/lib/Score.d.ts
+++ b/dist/esm/lib/Score.d.ts
@@ -1,7 +1,7 @@
 import { type ChordName } from "../const/chords_notes";
 import { type PresetName } from "../const/presets";
 import { Tone } from "./Tone";
-type ScoreEventName = "change" | "process";
+type ScoreEventName = "change" | "process" | "playingchange";
 type ScoreEvent<K extends ScoreEventName> = Event & {
     type: K;
     target: Score;

--- a/dist/esm/lib/Score.js
+++ b/dist/esm/lib/Score.js
@@ -203,6 +203,7 @@ export class Score extends EventTarget {
             }
         }
         this.process();
+        this.emit("playingchange");
     }
     stop() {
         clearTimeout(this.timer);
@@ -213,6 +214,7 @@ export class Score extends EventTarget {
                 tone.stop();
             }
         }
+        this.emit("playingchange");
     }
     seek(frame) {
         if (!Number.isInteger(frame)) {

--- a/src/lib/Score.ts
+++ b/src/lib/Score.ts
@@ -6,7 +6,7 @@ import {
 import { getPreset, PRESET_NAMES, type PresetName } from "../const/presets";
 import { Tone } from "./Tone";
 
-type ScoreEventName = "change" | "process";
+type ScoreEventName = "change" | "process" | "playingchange";
 type ScoreEvent<K extends ScoreEventName> = Event & { type: K; target: Score };
 
 type Fixed16Array<T> = [T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T];
@@ -290,6 +290,7 @@ export class Score extends EventTarget implements IScore {
       }
     }
     this.process();
+    this.emit("playingchange");
   }
 
   stop() {
@@ -301,6 +302,7 @@ export class Score extends EventTarget implements IScore {
         tone.stop();
       }
     }
+    this.emit("playingchange");
   }
 
   seek(frame: number): Error | undefined {


### PR DESCRIPTION
## Summary

- `Score` クラスに `playingchange` イベントを追加
- `play()` 呼び出し時（`playing = true`）と `stop()` 呼び出し時（`playing = false`）に発火
- `destroy()` 時は発火しない
- イベントオブジェクトは plain `Event`。リスナーは `e.target.playing` で現在値を参照

```typescript
score.on("playingchange", (e) => {
  console.log(e.target.playing); // true or false
});
```

## Changes

- `src/lib/Score.ts`: `ScoreEventName` に `"playingchange"` を追加。`play()` / `stop()` 末尾に `emit("playingchange")` を追加
- `__tests__/index.spec.ts`: `playingchange` の発火・非発火を検証するテスト3本を追加
- `dist/`: ビルド成果物を更新
- `README.md` / `CLAUDE.md`: イベントドキュメントを更新

## Test plan

- [ ] `play()` で `playingchange` が1回発火し、`e.target.playing === true` であること
- [ ] `stop()` で `playingchange` が1回発火し、`e.target.playing === false` であること
- [ ] `destroy()` では `playingchange` が発火しないこと
- [ ] `pnpm test` が全件パスすること