### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.6.0] - 2026-05-31
+
+### Features
+
+- `Score` クラスに `playingchange` イベントを追加: `play()` / `stop()` で再生状態が変わったときに発火。リスナーは `e.target.playing` で現在値（`true` / `false`）を参照できる。`destroy()` 時は発火しない
+
+---
+
 ## [v0.5.0] - 2026-05-30
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "score.ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A 16-step sequencer library built with Web Audio API and TypeScript, featuring chord-based tone generation with 48 chords, 6 traditional scales, and 10 sound presets",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

- `package.json` のバージョンを `0.5.0` → `0.6.0` に更新
- `CHANGELOG.md` に v0.6.0 の変更内容を追記

## Changes in v0.6.0

- `Score` クラスに `playingchange` イベントを追加（#12）

## Test plan

- [ ] `pnpm test` が全件パスすること
- [ ] `pnpm build` でビルドエラーが出ないこと