### PR TITLE
feat: sprinkle / clear メソッドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ score.stop();
 | `setChord(measureIndex, chord)` | 指定小節のコードを変更 |
 | `setPreset(preset: PresetName)` | 音色プリセットを変更 |
 | `setSpeed(speed: number)` | 再生速度を設定（フレーム/秒） |
-| `randomize(measureIndex, callback?)` | 指定小節をランダム化 |
+| `randomize(measureIndex, callback?)` | 指定小節をランダム化（全ノートを上書き） |
+| `sprinkle(measureIndex)` | 指定小節の各フレームに1〜2ノートをランダム追加（既存ノートを保持） |
+| `clear(measureIndex)` | 指定小節の全ノートを消去 |
 | `play()` | 再生開始（stop() 後の再開も可） |
 | `stop()` | 再生停止（OscillatorNode は維持されるため、play() で再開できる） |
 | `seek(frame: number)` | 再生位置を任意のフレームに移動（0〜小節数×16-1） |

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -288,6 +288,45 @@ describe("Score Class", () => {
     expect(score.randomize(5)).toBeInstanceOf(Error);
   });
 
+  test("sprinkle adds notes without removing existing ones", () => {
+    const score = new Score();
+    score.addMeasure();
+    score.toggleNote(1, 0, 0);
+    score.toggleNote(1, 0, 1);
+    score.sprinkle(1);
+    const after = score.data.measures[1].frames[0];
+    expect(after[0]).toBe(1);
+    expect(after[1]).toBe(1);
+  });
+
+  test("sprinkle on full frame does not change it", () => {
+    const score = new Score();
+    score.addMeasure();
+    // フレーム 0 を全て 1 にする
+    for (let i = 0; i < 16; i++) {
+      score.toggleNote(1, 0, i, 1);
+    }
+    const before = score.data.measures[1].frames[0].slice();
+    score.sprinkle(1);
+    expect(score.data.measures[1].frames[0]).toEqual(before);
+  });
+
+  test("sprinkle on empty measure adds 1 or 2 notes per frame", () => {
+    const score = new Score();
+    score.addMeasure();
+    score.sprinkle(1);
+    for (const frame of score.data.measures[1].frames) {
+      const count = frame.filter((n) => n === 1).length;
+      expect(count).toBeGreaterThanOrEqual(1);
+      expect(count).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test("sprinkle out of range", () => {
+    const score = new Score();
+    expect(score.sprinkle(5)).toBeInstanceOf(Error);
+  });
+
   test("play", () => {
     jest.useFakeTimers();
     const score = new Score();

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -288,6 +288,18 @@ describe("Score Class", () => {
     expect(score.randomize(5)).toBeInstanceOf(Error);
   });
 
+  test("clear measure", () => {
+    const score = new Score();
+    score.init(dummyData);
+    score.clear(0);
+    expect(score.data.measures[0].frames).toEqual(emptyMeasure);
+  });
+
+  test("clear out of range", () => {
+    const score = new Score();
+    expect(score.clear(5)).toBeInstanceOf(Error);
+  });
+
   test("sprinkle adds notes without removing existing ones", () => {
     const score = new Score();
     score.addMeasure();

--- a/dist/cjs/lib/Score.d.ts
+++ b/dist/cjs/lib/Score.d.ts
@@ -27,6 +27,7 @@ interface IScore {
     setPreset: (preset: PresetName) => Error | undefined;
     setSpeed: (speed: number) => Error | undefined;
     randomize: (measureIndex: number, callback?: () => boolean) => Error | undefined;
+    sprinkle: (measureIndex: number) => Error | undefined;
     play: () => void;
     stop: () => void;
     seek: (frame: number) => Error | undefined;
@@ -56,6 +57,7 @@ export declare class Score extends EventTarget implements IScore {
     setPreset(preset: PresetName): Error | undefined;
     setSpeed(speed: number): Error | undefined;
     randomize(measureIndex: number, callback?: () => boolean): Error | undefined;
+    sprinkle(measureIndex: number): Error | undefined;
     play(): void;
     stop(): void;
     seek(frame: number): Error | undefined;

--- a/dist/cjs/lib/Score.d.ts
+++ b/dist/cjs/lib/Score.d.ts
@@ -28,6 +28,7 @@ interface IScore {
     setSpeed: (speed: number) => Error | undefined;
     randomize: (measureIndex: number, callback?: () => boolean) => Error | undefined;
     sprinkle: (measureIndex: number) => Error | undefined;
+    clear: (measureIndex: number) => Error | undefined;
     play: () => void;
     stop: () => void;
     seek: (frame: number) => Error | undefined;
@@ -57,6 +58,7 @@ export declare class Score extends EventTarget implements IScore {
     setPreset(preset: PresetName): Error | undefined;
     setSpeed(speed: number): Error | undefined;
     randomize(measureIndex: number, callback?: () => boolean): Error | undefined;
+    clear(measureIndex: number): Error | undefined;
     sprinkle(measureIndex: number): Error | undefined;
     play(): void;
     stop(): void;

--- a/dist/cjs/lib/Score.js
+++ b/dist/cjs/lib/Score.js
@@ -16,6 +16,14 @@ const u = {
     random: () => {
         return Math.random() > 0.75;
     },
+    shuffle: (arr) => {
+        const result = [...arr];
+        for (let i = result.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [result[i], result[j]] = [result[j], result[i]];
+        }
+        return result;
+    },
 };
 const createEmptyFrames = () => {
     return Array.from({ length: 16 }).map(() => {
@@ -192,6 +200,22 @@ class Score extends EventTarget {
         }
         const frames = measure.frames.map((frame) => {
             return frame.map(() => (callback() ? 1 : 0));
+        });
+        measure.frames = frames;
+        this.emit("change");
+    }
+    sprinkle(measureIndex) {
+        const measure = this.data.measures.at(measureIndex);
+        if (!measure) {
+            return new Error("measure index out of range");
+        }
+        const frames = measure.frames.map((frame) => {
+            const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
+            if (emptyIndices.length === 0)
+                return frame;
+            const count = Math.min(Math.random() < 2 / 3 ? 1 : 2, emptyIndices.length);
+            const picked = new Set(u.shuffle(emptyIndices).slice(0, count));
+            return frame.map((note, i) => picked.has(i) ? 1 : note);
         });
         measure.frames = frames;
         this.emit("change");

--- a/dist/cjs/lib/Score.js
+++ b/dist/cjs/lib/Score.js
@@ -204,6 +204,14 @@ class Score extends EventTarget {
         measure.frames = frames;
         this.emit("change");
     }
+    clear(measureIndex) {
+        const measure = this.data.measures.at(measureIndex);
+        if (!measure) {
+            return new Error("measure index out of range");
+        }
+        measure.frames = createEmptyFrames();
+        this.emit("change");
+    }
     sprinkle(measureIndex) {
         const measure = this.data.measures.at(measureIndex);
         if (!measure) {

--- a/dist/cjs/lib/Score.js
+++ b/dist/cjs/lib/Score.js
@@ -213,7 +213,7 @@ class Score extends EventTarget {
             const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
             if (emptyIndices.length === 0)
                 return frame;
-            const count = Math.min(Math.random() < 2 / 3 ? 1 : 2, emptyIndices.length);
+            const count = Math.min(Math.random() < 0.8 ? 1 : 2, emptyIndices.length);
             const picked = new Set(u.shuffle(emptyIndices).slice(0, count));
             return frame.map((note, i) => picked.has(i) ? 1 : note);
         });

--- a/dist/esm/lib/Score.d.ts
+++ b/dist/esm/lib/Score.d.ts
@@ -27,6 +27,7 @@ interface IScore {
     setPreset: (preset: PresetName) => Error | undefined;
     setSpeed: (speed: number) => Error | undefined;
     randomize: (measureIndex: number, callback?: () => boolean) => Error | undefined;
+    sprinkle: (measureIndex: number) => Error | undefined;
     play: () => void;
     stop: () => void;
     seek: (frame: number) => Error | undefined;
@@ -56,6 +57,7 @@ export declare class Score extends EventTarget implements IScore {
     setPreset(preset: PresetName): Error | undefined;
     setSpeed(speed: number): Error | undefined;
     randomize(measureIndex: number, callback?: () => boolean): Error | undefined;
+    sprinkle(measureIndex: number): Error | undefined;
     play(): void;
     stop(): void;
     seek(frame: number): Error | undefined;

--- a/dist/esm/lib/Score.d.ts
+++ b/dist/esm/lib/Score.d.ts
@@ -28,6 +28,7 @@ interface IScore {
     setSpeed: (speed: number) => Error | undefined;
     randomize: (measureIndex: number, callback?: () => boolean) => Error | undefined;
     sprinkle: (measureIndex: number) => Error | undefined;
+    clear: (measureIndex: number) => Error | undefined;
     play: () => void;
     stop: () => void;
     seek: (frame: number) => Error | undefined;
@@ -57,6 +58,7 @@ export declare class Score extends EventTarget implements IScore {
     setPreset(preset: PresetName): Error | undefined;
     setSpeed(speed: number): Error | undefined;
     randomize(measureIndex: number, callback?: () => boolean): Error | undefined;
+    clear(measureIndex: number): Error | undefined;
     sprinkle(measureIndex: number): Error | undefined;
     play(): void;
     stop(): void;

--- a/dist/esm/lib/Score.js
+++ b/dist/esm/lib/Score.js
@@ -201,6 +201,14 @@ export class Score extends EventTarget {
         measure.frames = frames;
         this.emit("change");
     }
+    clear(measureIndex) {
+        const measure = this.data.measures.at(measureIndex);
+        if (!measure) {
+            return new Error("measure index out of range");
+        }
+        measure.frames = createEmptyFrames();
+        this.emit("change");
+    }
     sprinkle(measureIndex) {
         const measure = this.data.measures.at(measureIndex);
         if (!measure) {

--- a/dist/esm/lib/Score.js
+++ b/dist/esm/lib/Score.js
@@ -210,7 +210,7 @@ export class Score extends EventTarget {
             const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
             if (emptyIndices.length === 0)
                 return frame;
-            const count = Math.min(Math.random() < 2 / 3 ? 1 : 2, emptyIndices.length);
+            const count = Math.min(Math.random() < 0.8 ? 1 : 2, emptyIndices.length);
             const picked = new Set(u.shuffle(emptyIndices).slice(0, count));
             return frame.map((note, i) => picked.has(i) ? 1 : note);
         });

--- a/dist/esm/lib/Score.js
+++ b/dist/esm/lib/Score.js
@@ -13,6 +13,14 @@ const u = {
     random: () => {
         return Math.random() > 0.75;
     },
+    shuffle: (arr) => {
+        const result = [...arr];
+        for (let i = result.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [result[i], result[j]] = [result[j], result[i]];
+        }
+        return result;
+    },
 };
 const createEmptyFrames = () => {
     return Array.from({ length: 16 }).map(() => {
@@ -189,6 +197,22 @@ export class Score extends EventTarget {
         }
         const frames = measure.frames.map((frame) => {
             return frame.map(() => (callback() ? 1 : 0));
+        });
+        measure.frames = frames;
+        this.emit("change");
+    }
+    sprinkle(measureIndex) {
+        const measure = this.data.measures.at(measureIndex);
+        if (!measure) {
+            return new Error("measure index out of range");
+        }
+        const frames = measure.frames.map((frame) => {
+            const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
+            if (emptyIndices.length === 0)
+                return frame;
+            const count = Math.min(Math.random() < 2 / 3 ? 1 : 2, emptyIndices.length);
+            const picked = new Set(u.shuffle(emptyIndices).slice(0, count));
+            return frame.map((note, i) => picked.has(i) ? 1 : note);
         });
         measure.frames = frames;
         this.emit("change");

--- a/example/page.tsx
+++ b/example/page.tsx
@@ -276,6 +276,10 @@ export function Page() {
                 <ControlButton
                   type="button"
                   onClick={() => {
+                    if (data && data.measures.length === 1) {
+                      score?.clear(m);
+                      return;
+                    }
                     const e = score?.removeMeasure(m);
                     if (e instanceof Error) {
                       alert(e.message);

--- a/example/page.tsx
+++ b/example/page.tsx
@@ -7,6 +7,7 @@ import {
   FaStepBackward,
   FaTrash,
 } from "react-icons/fa";
+import { IoSparkles } from "react-icons/io5";
 import styled from "styled-components";
 import {
   CHORD_NAMES,
@@ -250,6 +251,17 @@ export function Page() {
                 })}
               </MeasureInner>
               <MeasureControlBase>
+                <ControlButton
+                  type="button"
+                  onClick={() => {
+                    const e = score?.sprinkle(m);
+                    if (e instanceof Error) {
+                      alert(e.message);
+                    }
+                  }}
+                >
+                  <IoSparkles />
+                </ControlButton>
                 <ControlButton
                   type="button"
                   onClick={() => {

--- a/src/lib/Score.ts
+++ b/src/lib/Score.ts
@@ -82,6 +82,7 @@ interface IScore {
     callback?: () => boolean,
   ) => Error | undefined;
   sprinkle: (measureIndex: number) => Error | undefined;
+  clear: (measureIndex: number) => Error | undefined;
   play: () => void;
   stop: () => void;
   seek: (frame: number) => Error | undefined;
@@ -286,6 +287,15 @@ export class Score extends EventTarget implements IScore {
       return frame.map(() => (callback() ? 1 : 0));
     });
     measure.frames = frames as Fixed16Array<Fixed16Array<NumBool>>;
+    this.emit("change");
+  }
+
+  clear(measureIndex: number): Error | undefined {
+    const measure = this.data.measures.at(measureIndex);
+    if (!measure) {
+      return new Error("measure index out of range");
+    }
+    measure.frames = createEmptyFrames();
     this.emit("change");
   }
 

--- a/src/lib/Score.ts
+++ b/src/lib/Score.ts
@@ -25,6 +25,14 @@ const u = {
   random: (): boolean => {
     return Math.random() > 0.75;
   },
+  shuffle: <T>(arr: T[]): T[] => {
+    const result = [...arr];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  },
 };
 
 interface Measure {
@@ -73,6 +81,7 @@ interface IScore {
     measureIndex: number,
     callback?: () => boolean,
   ) => Error | undefined;
+  sprinkle: (measureIndex: number) => Error | undefined;
   play: () => void;
   stop: () => void;
   seek: (frame: number) => Error | undefined;
@@ -275,6 +284,27 @@ export class Score extends EventTarget implements IScore {
     }
     const frames = measure.frames.map((frame) => {
       return frame.map(() => (callback() ? 1 : 0));
+    });
+    measure.frames = frames as Fixed16Array<Fixed16Array<NumBool>>;
+    this.emit("change");
+  }
+
+  sprinkle(measureIndex: number): Error | undefined {
+    const measure = this.data.measures.at(measureIndex);
+    if (!measure) {
+      return new Error("measure index out of range");
+    }
+    const frames = measure.frames.map((frame) => {
+      const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
+      if (emptyIndices.length === 0) return frame;
+      const count = Math.min(
+        Math.random() < 2 / 3 ? 1 : 2,
+        emptyIndices.length,
+      );
+      const picked = new Set(u.shuffle(emptyIndices).slice(0, count));
+      return frame.map((note, i) =>
+        picked.has(i) ? 1 : note,
+      ) as Fixed16Array<NumBool>;
     });
     measure.frames = frames as Fixed16Array<Fixed16Array<NumBool>>;
     this.emit("change");

--- a/src/lib/Score.ts
+++ b/src/lib/Score.ts
@@ -307,10 +307,7 @@ export class Score extends EventTarget implements IScore {
     const frames = measure.frames.map((frame) => {
       const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
       if (emptyIndices.length === 0) return frame;
-      const count = Math.min(
-        Math.random() < 0.8 ? 1 : 2,
-        emptyIndices.length,
-      );
+      const count = Math.min(Math.random() < 0.8 ? 1 : 2, emptyIndices.length);
       const picked = new Set(u.shuffle(emptyIndices).slice(0, count));
       return frame.map((note, i) =>
         picked.has(i) ? 1 : note,

--- a/src/lib/Score.ts
+++ b/src/lib/Score.ts
@@ -298,7 +298,7 @@ export class Score extends EventTarget implements IScore {
       const emptyIndices = frame.flatMap((note, i) => (note === 0 ? [i] : []));
       if (emptyIndices.length === 0) return frame;
       const count = Math.min(
-        Math.random() < 2 / 3 ? 1 : 2,
+        Math.random() < 0.8 ? 1 : 2,
         emptyIndices.length,
       );
       const picked = new Set(u.shuffle(emptyIndices).slice(0, count));


### PR DESCRIPTION
## Summary

`Score` クラスに `sprinkle()` と `clear()` の2メソッドを追加。`sprinkle()` は既存ノートを保持しつつ各フレームにランダムで1〜2ノートを追加する。`clear()` は指定小節の全ノートを消去する。あわせて example アプリにも両機能のボタンを追加した。

## Changes

- `Score` クラスに `sprinkle(measureIndex)` を追加（`src/lib/Score.ts`）
  - 各フレームの空きノートからランダムに1〜2個を選んで追加
  - 1ノート追加の確率 80%、2ノート追加の確率 20%（Fisher-Yates シャッフル使用）
  - 既存の1は保持、空きなしフレームはスキップ
- `Score` クラスに `clear(measureIndex)` を追加（`src/lib/Score.ts`）
  - 指定小節の全フレームを空（0）にリセット
- `IScore` インターフェースに両メソッドを追加
- テストを7件追加（`__tests__/index.spec.ts`）
- example アプリに `sprinkle` ボタン（`IoSparkles` アイコン）を追加（`example/page.tsx`）
- example の trash ボタンを改修: 小節が1つのときは削除の代わりに `clear()` でノートをクリア
- README のメソッド一覧に `sprinkle` / `clear` を追記

## Review Points

- `sprinkle` の確率分布（80/20）と上限2ノートが意図した使用感になっているか
- `clear` の責務（ノートのみリセット、コードや小節数は変えない）が適切か