### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.7.0] - 2026-06-13
+
+### Features
+
+- `Score` クラスに `sprinkle(measureIndex)` を追加: 指定小節の各フレームに空きノートをランダムに1〜2個有効化する
+- `Score` クラスに `clear(measureIndex)` を追加: 指定小節の全ノートをクリアする
+
+---
+
 ## [v0.6.0] - 2026-05-31
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "score.ts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A 16-step sequencer library built with Web Audio API and TypeScript, featuring chord-based tone generation with 48 chords, 6 traditional scales, and 10 sound presets",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary
`Score` クラスに `sprinkle()` と `clear()` メソッドを追加し、ノートの一括操作を可能にする v0.7.0 のリリース PR。

## Changes
- `Score.sprinkle(measureIndex)` を追加: 指定小節の各フレームに空きノートをランダムに1〜2個有効化する
- `Score.clear(measureIndex)` を追加: 指定小節の全ノートをクリアする
- `package.json` バージョンを `0.6.0` → `0.7.0` に更新
- `CHANGELOG.md` に v0.7.0 の変更内容を追記

## Review Points
- `sprinkle()` のランダム配置ロジック（確率 0.8 で1個、0.2 で2個）が意図通りか