### PR TITLE
Release v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "score.ts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A 16-step sequencer library built with Web Audio API and TypeScript, featuring chord-based tone generation with 48 chords, 6 traditional scales, and 10 sound presets",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary
score.ts v0.7.0 → v0.8.0 のリリース PR。beat / drum 機能の追加に伴う minor バージョンアップ。

## Changes
- feat: beat / drum 機能を追加 (#17)
  - `Drum` クラス追加（キック: OscillatorNode の周波数スウィープ、ハイハット: BiquadFilter + ホワイトノイズ）
  - `BeatPattern` 型・`BEAT_PATTERNS` 定数・9 種類のビートパターンを公開 API に追加
  - `Score` に `setBeat()` を追加、`IScoreData.beat` で省略可
  - 3 層ゲイン階層（masterGain / chordGain / drumGain）の導入
- chore: package.json の version を 0.8.0 に bump

## Breaking Changes
なし（`beat` は optional で後方互換）

## Review Points
- バージョン番号: `package.json` の `0.7.0 → 0.8.0`
- typecheck / lint / test (51/51) 全て通過済み